### PR TITLE
board/PoC_finger-module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "arraydeque"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ffd3d69bd89910509a5d31d1f1353f38ccffdd116dd0099bbd6627f7bd8ad8"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.7",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,12 +63,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cat_esp32s3_rust"
 version = "0.1.0"
 dependencies = [
+ "critical-section",
  "esp-backtrace",
  "esp-println",
  "esp32s3-hal",
+ "keyberon",
 ]
 
 [[package]]
@@ -112,6 +138,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "embedded-dma"
@@ -265,10 +297,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -290,6 +371,20 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "keyberon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cce60bb6c512d5b559f04269cc91893fa63b1bdc9f861a45c63c2ab44e11489"
+dependencies = [
+ "arraydeque",
+ "either",
+ "embedded-hal",
+ "generic-array 0.13.3",
+ "heapless",
+ "usb-device",
 ]
 
 [[package]]
@@ -538,6 +633,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,15 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ffd3d69bd89910509a5d31d1f1353f38ccffdd116dd0099bbd6627f7bd8ad8"
 
 [[package]]
-name = "as-slice"
-version = "0.1.5"
+name = "atomic-polyfill"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.7",
- "stable_deref_trait",
+ "critical-section",
 ]
 
 [[package]]
@@ -77,7 +74,8 @@ dependencies = [
  "esp-backtrace",
  "esp-println",
  "esp32s3-hal",
- "generic-array 0.14.7",
+ "generic-array",
+ "heapless",
  "keyberon",
 ]
 
@@ -300,24 +298,6 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
@@ -328,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
 ]
@@ -343,13 +323,14 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heapless"
-version = "0.5.6"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
- "as-slice",
- "generic-array 0.13.3",
+ "atomic-polyfill",
  "hash32",
+ "rustc_version",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -377,16 +358,25 @@ dependencies = [
 
 [[package]]
 name = "keyberon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cce60bb6c512d5b559f04269cc91893fa63b1bdc9f861a45c63c2ab44e11489"
+version = "0.2.0"
+source = "git+https://github.com/Ben-PH/keyberon#24bd53f850bb5f07b1eee36fe3ac75082d439c10"
 dependencies = [
  "arraydeque",
  "either",
  "embedded-hal",
- "generic-array 0.13.3",
  "heapless",
+ "keyberon-macros",
  "usb-device",
+]
+
+[[package]]
+name = "keyberon-macros"
+version = "0.1.0"
+source = "git+https://github.com/Ben-PH/keyberon#24bd53f850bb5f07b1eee36fe3ac75082d439c10"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -523,6 +513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +532,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "generic-array",
  "heapless",
  "keyberon",
+ "transpose",
 ]
 
 [[package]]
@@ -473,18 +474,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -556,7 +557,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -615,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -639,6 +640,16 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "transpose"
+version = "0.0.1"
+source = "git+https://github.com/Ben-PH/transpose#9583e7208ab6e13e118a71204c3566a6afad2103"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,8 +359,8 @@ dependencies = [
 
 [[package]]
 name = "keyberon"
-version = "0.2.0"
-source = "git+https://github.com/Ben-PH/keyberon#24bd53f850bb5f07b1eee36fe3ac75082d439c10"
+version = "0.3.0"
+source = "git+https://github.com/Ben-PH/keyberon#315165510f3605d67bc66ed19626b56e86668d4c"
 dependencies = [
  "arraydeque",
  "either",
@@ -373,7 +373,7 @@ dependencies = [
 [[package]]
 name = "keyberon-macros"
 version = "0.1.0"
-source = "git+https://github.com/Ben-PH/keyberon#24bd53f850bb5f07b1eee36fe3ac75082d439c10"
+source = "git+https://github.com/Ben-PH/keyberon#315165510f3605d67bc66ed19626b56e86668d4c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,11 @@ name = "cat_esp32s3_rust"
 version = "0.1.0"
 dependencies = [
  "critical-section",
+ "embedded-hal",
  "esp-backtrace",
  "esp-println",
  "esp32s3-hal",
+ "generic-array 0.14.7",
  "keyberon",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ critical-section = "1.1.1"
 embedded-hal = "0.2.7"
 generic-array = "0.14.7"
 heapless = "0.7.16"
+transpose = {git = "https://github.com/Ben-PH/transpose"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ license = "MIT OR Apache-2.0"
 hal = { package = "esp32s3-hal", version = "0.9.0" }
 esp-backtrace = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32s3"] }
+keyberon = "0.1.1"
+critical-section = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ license = "MIT OR Apache-2.0"
 hal = { package = "esp32s3-hal", version = "0.9.0" }
 esp-backtrace = { version = "0.7.0", features = ["esp32s3", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.5.0", features = ["esp32s3"] }
-keyberon = "0.1.1"
+keyberon = {git = "https://github.com/Ben-PH/keyberon"}
 critical-section = "1.1.1"
 embedded-hal = "0.2.7"
 generic-array = "0.14.7"
+heapless = "0.7.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ esp-backtrace = { version = "0.7.0", features = ["esp32s3", "panic-handler", "ex
 esp-println       = { version = "0.5.0", features = ["esp32s3"] }
 keyberon = "0.1.1"
 critical-section = "1.1.1"
+embedded-hal = "0.2.7"
+generic-array = "0.14.7"

--- a/src/board_modules.rs
+++ b/src/board_modules.rs
@@ -1,0 +1,1 @@
+pub mod left_finger;

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -1,15 +1,15 @@
 use core::convert::Infallible;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use esp_backtrace as _;
-use generic_array::typenum::{U4, U6};
-use hal::gpio::{Input, Output, PullUp, PushPull};
-use hal::{gpio, IO};
-use keyberon::debounce::Debouncer;
+use generic_array::typenum::{U3, U6};
+use hal::gpio::{self, Input, Output, Pins, PullUp, PushPull};
 use keyberon::impl_heterogenous_array;
+use keyberon::key_code::KeyCode;
 use keyberon::matrix::Matrix;
+use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
 /// Physical pins corresponding to left-finger module, oriented left-to-right
-struct LeftFingerCol(
+pub struct LeftFingerCol(
     gpio::Gpio37<Input<PullUp>>,
     gpio::Gpio38<Input<PullUp>>,
     gpio::Gpio39<Input<PullUp>>,
@@ -24,23 +24,30 @@ impl_heterogenous_array! {
     [0, 1, 2, 3, 4, 5]
 }
 /// Physical pins corresponding to left-finger module, oriented top-to-bottom
-struct LeftFingerRow(
-    gpio::Gpio21<Output<PushPull>>,
+pub struct LeftFingerRow(
+    // gpio::Gpio21<Output<PushPull>>,
     gpio::Gpio47<Output<PushPull>>,
     gpio::Gpio48<Output<PushPull>>,
     gpio::Gpio45<Output<PushPull>>,
 );
+use KeyCode::*;
+static LAYOUT: Layers = &[&[
+    &[k(A), k(B), k(C), k(D), k(E), k(F)],
+    &[k(G), k(H), k(I), k(J), k(K), k(L)],
+    &[k(M), k(N), k(O), k(P), k(Q), k(R)],
+]];
 
 impl_heterogenous_array! {
     LeftFingerRow,
     dyn OutputPin<Error = Infallible>,
-    U4,
-    [0, 1, 2, 3]
+    U3,
+    [0, 1, 2]
 }
 
 pub struct BoardLeftFinger {
-    matrix: Matrix<LeftFingerCol, LeftFingerRow>,
-    debouncer: Debouncer<[[bool; 6]; 4]>,
+    pub matrix: Matrix<LeftFingerCol, LeftFingerRow>,
+    pub debouncer: Debouncer<[[bool; 6]; 3]>,
+    pub layout: Layers,
 }
 
 impl BoardLeftFinger {
@@ -49,32 +56,30 @@ impl BoardLeftFinger {
     /// let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     /// let (board_left_finger, io) = left_finger::BoardLeftFinger::new(io);
     /// ```
-    pub fn new(io: IO) -> (Self, IO) {
+    pub fn new(pins: Pins) -> Self {
         let matrix = Matrix::new(
             LeftFingerCol(
-                io.pins.gpio37.into_pull_up_input(),
-                io.pins.gpio38.into_pull_up_input(),
-                io.pins.gpio39.into_pull_up_input(),
-                io.pins.gpio40.into_pull_up_input(),
-                io.pins.gpio41.into_pull_up_input(),
-                io.pins.gpio42.into_pull_up_input(),
+                pins.gpio37.into_pull_up_input(),
+                pins.gpio38.into_pull_up_input(),
+                pins.gpio39.into_pull_up_input(),
+                pins.gpio40.into_pull_up_input(),
+                pins.gpio41.into_pull_up_input(),
+                pins.gpio42.into_pull_up_input(),
             ),
             LeftFingerRow(
-                io.pins.gpio21.into_push_pull_output(),
-                io.pins.gpio47.into_push_pull_output(),
-                io.pins.gpio48.into_push_pull_output(),
-                io.pins.gpio45.into_push_pull_output(),
+                // pins.gpio21.into_push_pull_output(),
+                pins.gpio47.into_push_pull_output(),
+                pins.gpio48.into_push_pull_output(),
+                pins.gpio45.into_push_pull_output(),
             ),
         )
         .unwrap();
-        let debounce = || [[false; 6]; 4];
+        let debounce = || [[false; 6]; 3];
 
-        (
-            Self {
-                matrix,
-                debouncer: Debouncer::new(debounce(), debounce(), 5),
-            },
-            io,
-        )
+        Self {
+            matrix,
+            debouncer: Debouncer::new(debounce(), debounce(), 5),
+            layout: LAYOUT,
+        }
     }
 }

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -6,18 +6,16 @@ use keyberon::matrix::Matrix;
 use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
 use KeyCode::*;
-#[rustfmt::skip]
-static LAYOUT: Layers<4, 6, 1> = [[
-    [k(No),     k(No), k(A), k(Z)],
-    [k(No),     k(Q), k(S), k(X)],
-    [k(Escape), k(W), k(D), k(C)],
-    [k(LCtrl),  k(E), k(F), k(V)],
-    [k(LAlt),   k(R), k(G), k(B)],
-    [k(No),     k(T), k(Q), k(R)],
-]];
 
-/// Note: keyberon::matrix::Matrix assumes input is column,
-/// while lynx-cat hardware has row as input.
+#[rustfmt::skip]
+static LAYOUT: Layers<4, 6, 1> = [transpose::transpose!{[
+    [k(No), k(No), k(Escape), k(LCtrl), k(LAlt), k(No)],
+    [k(No), k(Q),  k(W),      k(E),     k(R),    k(T)],
+    [k(A),  k(S),  k(D),      k(F),     k(G),    k(Q)],
+    [k(Z),  k(X),  k(C),      k(V),     k(B),    k(R)],
+]}];
+
+/// 4 rows, 6 columns per row, just the one layer
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
     pub matrix: Matrix<C, R, 4, 6>,
     pub debouncer: Debouncer<[[bool; 4]; 6]>,

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -1,22 +1,24 @@
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use esp_backtrace as _;
-use hal::gpio::{Input, Output, Pins, PullUp, PushPull, AnyPin};
+use hal::gpio::{AnyPin, Input, Output, Pins, PullUp, PushPull};
 use keyberon::key_code::KeyCode;
 use keyberon::matrix::Matrix;
 use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
 use KeyCode::*;
-static LAYOUT: Layers<6, 3, 1> = [[
-    [k(A), k(B), k(C), k(D), k(E), k(F)],
-    [k(G), k(H), k(I), k(J), k(K), k(L)],
-    [k(M), k(N), k(O), k(P), k(Q), k(R)],
+static LAYOUT: Layers<3, 6, 1> = [[
+    [k(A), k(B), k(C)],
+    [k(D), k(E), k(F)],
+    [k(G), k(H), k(I)],
+    [k(J), k(K), k(L)],
+    [k(M), k(N), k(O)],
+    [k(P), k(Q), k(R)],
 ]];
 
-
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
-    pub matrix: Matrix<C, R, 6, 3>,
-    pub debouncer: Debouncer<[[bool; 6]; 3]>,
-    pub layout: Layers<6, 3, 1>,
+    pub matrix: Matrix<C, R, 3, 6>,
+    pub debouncer: Debouncer<[[bool; 3]; 6]>,
+    pub layout: Layers<3, 6, 1>,
 }
 
 impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
@@ -28,26 +30,26 @@ impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
     pub fn new(pins: Pins) -> Self {
         let matrix = Matrix::new(
             [
-                pins.gpio37.into_pull_up_input().degrade(),
-                pins.gpio38.into_pull_up_input().degrade(),
-                pins.gpio39.into_pull_up_input().degrade(),
-                pins.gpio40.into_pull_up_input().degrade(),
-                pins.gpio41.into_pull_up_input().degrade(),
-                pins.gpio42.into_pull_up_input().degrade(),
+                pins.gpio47.into_pull_up_input().degrade(),
+                pins.gpio48.into_pull_up_input().degrade(),
+                pins.gpio45.into_pull_up_input().degrade(),
             ],
             [
                 // pins.gpio21.into_push_pull_output(),
-                pins.gpio47.into_push_pull_output().degrade(),
-                pins.gpio48.into_push_pull_output().degrade(),
-                pins.gpio45.into_push_pull_output().degrade(),
+                pins.gpio37.into_push_pull_output().degrade(),
+                pins.gpio38.into_push_pull_output().degrade(),
+                pins.gpio39.into_push_pull_output().degrade(),
+                pins.gpio40.into_push_pull_output().degrade(),
+                pins.gpio41.into_push_pull_output().degrade(),
+                pins.gpio42.into_push_pull_output().degrade(),
             ],
         )
         .unwrap();
-        let debounce = || [[false; 6]; 3];
+        let debounce = || [[false; 3]; 6];
 
         Self {
             matrix,
-            debouncer: Debouncer::new(debounce(), debounce(), 5),
+            debouncer: Debouncer::new(debounce(), debounce(), 50),
             layout: LAYOUT,
         }
     }

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -8,18 +8,18 @@ use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 use KeyCode::*;
 
 #[rustfmt::skip]
-static LAYOUT: Layers<4, 6, 1> = [transpose::transpose!{[
+static LAYOUT: Layers<6, 4, 1> = [[
     [k(No), k(No), k(Escape), k(LCtrl), k(LAlt), k(No)],
     [k(No), k(Q),  k(W),      k(E),     k(R),    k(T)],
     [k(A),  k(S),  k(D),      k(F),     k(G),    k(Q)],
     [k(Z),  k(X),  k(C),      k(V),     k(B),    k(R)],
-]}];
+]];
 
 /// 4 rows, 6 columns per row, just the one layer
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
     pub matrix: Matrix<C, R, 4, 6>,
     pub debouncer: Debouncer<[[bool; 4]; 6]>,
-    pub layout: Layers<4, 6, 1>,
+    pub layout: Layers<6, 4, 1>,
 }
 
 impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -7,12 +7,12 @@ use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
 use KeyCode::*;
 static LAYOUT: Layers<3, 6, 1> = [[
-    [k(A), k(B), k(C)],
-    [k(D), k(E), k(F)],
-    [k(G), k(H), k(I)],
-    [k(J), k(K), k(L)],
-    [k(M), k(N), k(O)],
-    [k(P), k(Q), k(R)],
+    [k(Q), k(A), k(Z)],
+    [k(W), k(S), k(X)],
+    [k(E), k(D), k(C)],
+    [k(R), k(F), k(V)],
+    [k(T), k(G), k(B)],
+    [k(Y), k(Q), k(R)],
 ]];
 
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -15,6 +15,8 @@ static LAYOUT: Layers<3, 6, 1> = [[
     [k(Y), k(Q), k(R)],
 ]];
 
+/// Note: keyberon::matrix::Matrix assumes input is column, 
+/// while lynx-cat hardware has row as input. 
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
     pub matrix: Matrix<C, R, 3, 6>,
     pub debouncer: Debouncer<[[bool; 3]; 6]>,
@@ -22,11 +24,6 @@ pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
 }
 
 impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
-    /// The consumed IO is returned
-    /// ```ignore
-    /// let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    /// let (board_left_finger, io) = left_finger::BoardLeftFinger::new(io);
-    /// ```
     pub fn new(pins: Pins) -> Self {
         let matrix = Matrix::new(
             [

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -6,27 +6,29 @@ use keyberon::matrix::Matrix;
 use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
 use KeyCode::*;
-static LAYOUT: Layers<3, 6, 1> = [[
-    [k(Q), k(A), k(Z)],
-    [k(W), k(S), k(X)],
-    [k(E), k(D), k(C)],
-    [k(R), k(F), k(V)],
-    [k(T), k(G), k(B)],
-    [k(Y), k(Q), k(R)],
+#[rustfmt::skip]
+static LAYOUT: Layers<4, 6, 1> = [[
+    [k(No),     k(No), k(A), k(Z)],
+    [k(No),     k(Q), k(S), k(X)],
+    [k(Escape), k(W), k(D), k(C)],
+    [k(LCtrl),  k(E), k(F), k(V)],
+    [k(LAlt),   k(R), k(G), k(B)],
+    [k(No),     k(T), k(Q), k(R)],
 ]];
 
-/// Note: keyberon::matrix::Matrix assumes input is column, 
-/// while lynx-cat hardware has row as input. 
+/// Note: keyberon::matrix::Matrix assumes input is column,
+/// while lynx-cat hardware has row as input.
 pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
-    pub matrix: Matrix<C, R, 3, 6>,
-    pub debouncer: Debouncer<[[bool; 3]; 6]>,
-    pub layout: Layers<3, 6, 1>,
+    pub matrix: Matrix<C, R, 4, 6>,
+    pub debouncer: Debouncer<[[bool; 4]; 6]>,
+    pub layout: Layers<4, 6, 1>,
 }
 
 impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
     pub fn new(pins: Pins) -> Self {
         let matrix = Matrix::new(
             [
+                pins.gpio21.into_pull_up_input().degrade(),
                 pins.gpio47.into_pull_up_input().degrade(),
                 pins.gpio48.into_pull_up_input().degrade(),
                 pins.gpio45.into_pull_up_input().degrade(),
@@ -42,7 +44,7 @@ impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
             ],
         )
         .unwrap();
-        let debounce = || [[false; 3]; 6];
+        let debounce = || [[false; 4]; 6];
 
         Self {
             matrix,

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -1,0 +1,80 @@
+use core::convert::Infallible;
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+use esp_backtrace as _;
+use generic_array::typenum::{U4, U6};
+use hal::gpio::{Input, Output, PullUp, PushPull};
+use hal::{gpio, IO};
+use keyberon::debounce::Debouncer;
+use keyberon::impl_heterogenous_array;
+use keyberon::matrix::Matrix;
+
+/// Physical pins corresponding to left-finger module, oriented left-to-right
+struct LeftFingerCol(
+    gpio::Gpio37<Input<PullUp>>,
+    gpio::Gpio38<Input<PullUp>>,
+    gpio::Gpio39<Input<PullUp>>,
+    gpio::Gpio40<Input<PullUp>>,
+    gpio::Gpio41<Input<PullUp>>,
+    gpio::Gpio42<Input<PullUp>>,
+);
+impl_heterogenous_array! {
+    LeftFingerCol,
+    dyn InputPin<Error = Infallible>,
+    U6,
+    [0, 1, 2, 3, 4, 5]
+}
+/// Physical pins corresponding to left-finger module, oriented top-to-bottom
+struct LeftFingerRow(
+    gpio::Gpio21<Output<PushPull>>,
+    gpio::Gpio47<Output<PushPull>>,
+    gpio::Gpio48<Output<PushPull>>,
+    gpio::Gpio45<Output<PushPull>>,
+);
+
+impl_heterogenous_array! {
+    LeftFingerRow,
+    dyn OutputPin<Error = Infallible>,
+    U4,
+    [0, 1, 2, 3]
+}
+
+pub struct BoardLeftFinger {
+    matrix: Matrix<LeftFingerCol, LeftFingerRow>,
+    debouncer: Debouncer<[[bool; 6]; 4]>,
+}
+
+impl BoardLeftFinger {
+    /// The consumed IO is returned
+    /// ```ignore
+    /// let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+    /// let (board_left_finger, io) = left_finger::BoardLeftFinger::new(io);
+    /// ```
+    pub fn new(io: IO) -> (Self, IO) {
+        let matrix = Matrix::new(
+            LeftFingerCol(
+                io.pins.gpio37.into_pull_up_input(),
+                io.pins.gpio38.into_pull_up_input(),
+                io.pins.gpio39.into_pull_up_input(),
+                io.pins.gpio40.into_pull_up_input(),
+                io.pins.gpio41.into_pull_up_input(),
+                io.pins.gpio42.into_pull_up_input(),
+            ),
+            LeftFingerRow(
+                io.pins.gpio21.into_push_pull_output(),
+                io.pins.gpio47.into_push_pull_output(),
+                io.pins.gpio48.into_push_pull_output(),
+                io.pins.gpio45.into_push_pull_output(),
+            ),
+        )
+        .unwrap();
+        let debounce = || [[false; 6]; 4];
+
+        (
+            Self {
+                matrix,
+                debouncer: Debouncer::new(debounce(), debounce(), 5),
+            },
+            io,
+        )
+    }
+}

--- a/src/board_modules/left_finger.rs
+++ b/src/board_modules/left_finger.rs
@@ -1,56 +1,25 @@
-use core::convert::Infallible;
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 use esp_backtrace as _;
-use generic_array::typenum::{U3, U6};
-use hal::gpio::{self, Input, Output, Pins, PullUp, PushPull};
-use keyberon::impl_heterogenous_array;
+use hal::gpio::{Input, Output, Pins, PullUp, PushPull, AnyPin};
 use keyberon::key_code::KeyCode;
 use keyberon::matrix::Matrix;
 use keyberon::{action::k, debounce::Debouncer, layout::Layers};
 
-/// Physical pins corresponding to left-finger module, oriented left-to-right
-pub struct LeftFingerCol(
-    gpio::Gpio37<Input<PullUp>>,
-    gpio::Gpio38<Input<PullUp>>,
-    gpio::Gpio39<Input<PullUp>>,
-    gpio::Gpio40<Input<PullUp>>,
-    gpio::Gpio41<Input<PullUp>>,
-    gpio::Gpio42<Input<PullUp>>,
-);
-impl_heterogenous_array! {
-    LeftFingerCol,
-    dyn InputPin<Error = Infallible>,
-    U6,
-    [0, 1, 2, 3, 4, 5]
-}
-/// Physical pins corresponding to left-finger module, oriented top-to-bottom
-pub struct LeftFingerRow(
-    // gpio::Gpio21<Output<PushPull>>,
-    gpio::Gpio47<Output<PushPull>>,
-    gpio::Gpio48<Output<PushPull>>,
-    gpio::Gpio45<Output<PushPull>>,
-);
 use KeyCode::*;
-static LAYOUT: Layers = &[&[
-    &[k(A), k(B), k(C), k(D), k(E), k(F)],
-    &[k(G), k(H), k(I), k(J), k(K), k(L)],
-    &[k(M), k(N), k(O), k(P), k(Q), k(R)],
+static LAYOUT: Layers<6, 3, 1> = [[
+    [k(A), k(B), k(C), k(D), k(E), k(F)],
+    [k(G), k(H), k(I), k(J), k(K), k(L)],
+    [k(M), k(N), k(O), k(P), k(Q), k(R)],
 ]];
 
-impl_heterogenous_array! {
-    LeftFingerRow,
-    dyn OutputPin<Error = Infallible>,
-    U3,
-    [0, 1, 2]
-}
 
-pub struct BoardLeftFinger {
-    pub matrix: Matrix<LeftFingerCol, LeftFingerRow>,
+pub struct BoardLeftFinger<C: InputPin, R: OutputPin> {
+    pub matrix: Matrix<C, R, 6, 3>,
     pub debouncer: Debouncer<[[bool; 6]; 3]>,
-    pub layout: Layers,
+    pub layout: Layers<6, 3, 1>,
 }
 
-impl BoardLeftFinger {
+impl BoardLeftFinger<AnyPin<Input<PullUp>>, AnyPin<Output<PushPull>>> {
     /// The consumed IO is returned
     /// ```ignore
     /// let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
@@ -58,20 +27,20 @@ impl BoardLeftFinger {
     /// ```
     pub fn new(pins: Pins) -> Self {
         let matrix = Matrix::new(
-            LeftFingerCol(
-                pins.gpio37.into_pull_up_input(),
-                pins.gpio38.into_pull_up_input(),
-                pins.gpio39.into_pull_up_input(),
-                pins.gpio40.into_pull_up_input(),
-                pins.gpio41.into_pull_up_input(),
-                pins.gpio42.into_pull_up_input(),
-            ),
-            LeftFingerRow(
+            [
+                pins.gpio37.into_pull_up_input().degrade(),
+                pins.gpio38.into_pull_up_input().degrade(),
+                pins.gpio39.into_pull_up_input().degrade(),
+                pins.gpio40.into_pull_up_input().degrade(),
+                pins.gpio41.into_pull_up_input().degrade(),
+                pins.gpio42.into_pull_up_input().degrade(),
+            ],
+            [
                 // pins.gpio21.into_push_pull_output(),
-                pins.gpio47.into_push_pull_output(),
-                pins.gpio48.into_push_pull_output(),
-                pins.gpio45.into_push_pull_output(),
-            ),
+                pins.gpio47.into_push_pull_output().degrade(),
+                pins.gpio48.into_push_pull_output().degrade(),
+                pins.gpio45.into_push_pull_output().degrade(),
+            ],
         )
         .unwrap();
         let debounce = || [[false; 6]; 3];

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 
 use esp_backtrace as _;
 use esp_println::println;
-use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc, IO};
+use keyberon::matrix::Matrix;
 
 #[entry]
 fn main() -> ! {
@@ -29,6 +30,29 @@ fn main() -> ! {
     wdt0.disable();
     wdt1.disable();
     println!("Hello world!");
+
+    let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
+
+    let mut pin43 = io.pins.gpio43.into_pull_up_input();
+    // pin43.listen(Event::FallingEdge);
+    // critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(pin43));
+
+    // interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority2).unwrap();
+     Matrix::new(
+                [
+                    io.pins.gpio3.into_pull_up_input().degrade(),
+                    io.pins.gpio4.into_pull_up_input().degrade(),
+                    io.pins.gpio5.into_pull_up_input().degrade(),
+                    io.pins.gpio8.into_pull_up_input().degrade(),
+                    io.pins.gpio9.into_pull_up_input().degrade(),
+                ],
+                [
+                    io.pins.gpio0.into_push_pull_output().degrade(),
+                    io.pins.gpio1.into_push_pull_output().degrade(),
+                    io.pins.gpio2.into_push_pull_output().degrade(),
+                    io.pins.gpio10.into_push_pull_output().degrade(),
+                ],
+            );
 
     #[allow(clippy::empty_loop)]
     loop {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,11 +41,13 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
     println!("Hello world!");
     for _ in 0.. {
-        // let events = board_left_finger.debouncer.get().events(board_left_finger.matrix.get().unwrap().iter_pressed()).collect::<heapless::Vec<_, 8>>();
-        // for (i, event) in events.iter().enumerate() {
-        //     println!("{}", i);
-        // }
-        delay.delay_ms(500u16);
+        let events = board_left_finger
+            .debouncer
+            .events(board_left_finger.matrix.get().unwrap())
+            .collect::<heapless::Vec<_, 8>>();
+        for (i, event) in events.iter().enumerate() {
+            println!("{:?}", event);
+        }
     }
     unreachable!()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     for _ in 0.. {
         let events = board_left_finger
             .debouncer
-            .events(board_left_finger.matrix.get().unwrap())
+            .events(board_left_finger.matrix.down_keys().unwrap(), Some(keyberon::debounce::transpose))
             .collect::<heapless::Vec<_, 8>>();
         for event in events.iter() {
             match event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,10 @@ fn main() -> ! {
     let mut delay = Delay::new(&clocks);
     println!("Hello world!");
     for _ in 0.. {
-        for _ in board_left_finger.matrix.get().unwrap().iter_pressed() {
-            println!("key");
-        }
+        // let events = board_left_finger.debouncer.get().events(board_left_finger.matrix.get().unwrap().iter_pressed()).collect::<heapless::Vec<_, 8>>();
+        // for (i, event) in events.iter().enumerate() {
+        //     println!("{}", i);
+        // }
         delay.delay_ms(500u16);
     }
     unreachable!()

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@
 
 use esp_backtrace as _;
 use esp_println::println;
-use hal::prelude::*;
 use hal::{clock::ClockControl, peripherals::Peripherals, timer::TimerGroup, Rtc, IO};
+use hal::{prelude::*, Delay};
 
 mod board_modules;
 use board_modules::left_finger;
@@ -36,8 +36,15 @@ fn main() -> ! {
     println!("Hello world!");
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-    let (board_left_finger, io) = left_finger::BoardLeftFinger::new(io);
+    let mut board_left_finger = left_finger::BoardLeftFinger::new(io.pins);
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    let mut delay = Delay::new(&clocks);
+    println!("Hello world!");
+    for _ in 0.. {
+        for _ in board_left_finger.matrix.get().unwrap().iter_pressed() {
+            println!("key");
+        }
+        delay.delay_ms(500u16);
+    }
+    unreachable!()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use hal::{prelude::*, Delay};
 
 mod board_modules;
 use board_modules::left_finger;
+use keyberon::layout::Event;
 
 #[entry]
 fn main() -> ! {
@@ -38,15 +39,23 @@ fn main() -> ! {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut board_left_finger = left_finger::BoardLeftFinger::new(io.pins);
 
-    let mut delay = Delay::new(&clocks);
     println!("Hello world!");
     for _ in 0.. {
         let events = board_left_finger
             .debouncer
             .events(board_left_finger.matrix.get().unwrap())
             .collect::<heapless::Vec<_, 8>>();
-        for (i, event) in events.iter().enumerate() {
-            println!("{:?}", event);
+        for event in events.iter() {
+            match event {
+                Event::Press(x, y) => println!(
+                    "P-{:?}",
+                    board_left_finger.layout[0][*x as usize][*y as usize]
+                ),
+                Event::Release(x, y) => println!(
+                    "R-{:?}",
+                    board_left_finger.layout[0][*x as usize][*y as usize]
+                ),
+            }
         }
     }
     unreachable!()

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use keyberon::layout::Event;
 
 #[entry]
 fn main() -> ! {
+    // Obtain board resources
     let peripherals = Peripherals::take();
     let mut system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
@@ -34,12 +35,13 @@ fn main() -> ! {
     rtc.rwdt.disable();
     wdt0.disable();
     wdt1.disable();
-    println!("Hello world!");
 
+    // Setup the board-left-finger module
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
     let mut board_left_finger = left_finger::BoardLeftFinger::new(io.pins);
 
-    println!("Hello world!");
+    // Demonstrate PoC using keyberon to read the matrix
+    println!("Begin reading keyboard");
     for _ in 0.. {
         let events = board_left_finger
             .debouncer

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
+#![warn(unused_imports)]
 #![no_std]
 #![no_main]
 
 use esp_backtrace as _;
 use esp_println::println;
-use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc, IO};
-use keyberon::matrix::Matrix;
+use hal::prelude::*;
+use hal::{clock::ClockControl, peripherals::Peripherals, timer::TimerGroup, Rtc, IO};
+
+mod board_modules;
+use board_modules::left_finger;
 
 #[entry]
 fn main() -> ! {
@@ -32,27 +36,7 @@ fn main() -> ! {
     println!("Hello world!");
 
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
-
-    let mut pin43 = io.pins.gpio43.into_pull_up_input();
-    // pin43.listen(Event::FallingEdge);
-    // critical_section::with(|cs| BUTTON.borrow_ref_mut(cs).replace(pin43));
-
-    // interrupt::enable(peripherals::Interrupt::GPIO, interrupt::Priority::Priority2).unwrap();
-     Matrix::new(
-                [
-                    io.pins.gpio3.into_pull_up_input().degrade(),
-                    io.pins.gpio4.into_pull_up_input().degrade(),
-                    io.pins.gpio5.into_pull_up_input().degrade(),
-                    io.pins.gpio8.into_pull_up_input().degrade(),
-                    io.pins.gpio9.into_pull_up_input().degrade(),
-                ],
-                [
-                    io.pins.gpio0.into_push_pull_output().degrade(),
-                    io.pins.gpio1.into_push_pull_output().degrade(),
-                    io.pins.gpio2.into_push_pull_output().degrade(),
-                    io.pins.gpio10.into_push_pull_output().degrade(),
-                ],
-            );
+    let (board_left_finger, io) = left_finger::BoardLeftFinger::new(io);
 
     #[allow(clippy::empty_loop)]
     loop {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@
 
 use esp_backtrace as _;
 use esp_println::println;
+use hal::prelude::*;
 use hal::{clock::ClockControl, peripherals::Peripherals, timer::TimerGroup, Rtc, IO};
-use hal::{prelude::*, Delay};
 
 mod board_modules;
 use board_modules::left_finger;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 use esp_backtrace as _;
 use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,10 @@ fn main() -> ! {
     for _ in 0.. {
         let events = board_left_finger
             .debouncer
-            .events(board_left_finger.matrix.down_keys().unwrap(), Some(keyberon::debounce::transpose))
+            .events(
+                board_left_finger.matrix.down_keys().unwrap(),
+                Some(keyberon::debounce::transpose),
+            )
             .collect::<heapless::Vec<_, 8>>();
         for event in events.iter() {
             match event {


### PR DESCRIPTION
Implements a finger board module using keyberon matrix, debouncer, and layout semantics, checking for keypresses in a hot-loop.

Still need to look at interupt-driven event-loop, making some types generic